### PR TITLE
Refactor commanders list to include abilities

### DIFF
--- a/packages/web/src/coh/commanders.test.ts
+++ b/packages/web/src/coh/commanders.test.ts
@@ -1,4 +1,4 @@
-import { searchCommanders } from "./commanders";
+import { getCommanderByRaces, getCommanderData, searchCommanders } from "./commanders";
 
 describe("Search Commanders Function test", () => {
   test("Finds at least 1 commander with full name", () => {
@@ -24,5 +24,48 @@ describe("Search Commanders Function test", () => {
     const searchQuery = "notfound";
     const foundCommanders = searchCommanders(searchQuery);
     expect(foundCommanders).toHaveLength(0);
+  });
+});
+
+describe("getCommanderData", () => {
+  test("Returns a Commander when commanderId is correct", () => {
+    const commander = getCommanderData("186413");
+    expect(commander).not.toBeNull();
+  });
+
+  test("Returns null when commanderId is not correct", () => {
+    const commander = getCommanderData("0000000");
+    expect(commander).toBeNull();
+  });
+
+  test("Returns a commander with sorted abilities according to command points", () => {
+    const commander = getCommanderData("186413");
+    const expectedAbilitiesNames = [
+      "Pathfinders",
+      "Paradrop .50cal M2HB Heavy Machine Gun",
+      "Paratroopers",
+      "Paradrop M1 57mm Anti-Tank Gun",
+      "P-47 Rocket Strike",
+    ];
+    expect(commander?.abilities.map((ability) => ability.name)).toEqual(expectedAbilitiesNames);
+  });
+});
+
+describe("getCommanderByRaces", () => {
+  test("Returns a list of commanders when race is correct", () => {
+    const commanders = getCommanderByRaces("wermacht");
+    expect(commanders).toHaveLength(23);
+  });
+
+  test("Returns a list of commanders with abilities being sorted", () => {
+    const commanders = getCommanderByRaces("wermacht");
+    commanders
+      .map((commander) => commander.abilities)
+      .forEach((abilities) => {
+        let expectedCommandPoints = abilities
+          .map((ability) => ability.commandPoints)
+          .sort((c1, c2) => +c1 - +c2);
+        expect(abilities.map((ability) => ability.commandPoints)).toEqual(expectedCommandPoints);
+      });
   });
 });

--- a/packages/web/src/coh/commanders.ts
+++ b/packages/web/src/coh/commanders.ts
@@ -28,20 +28,32 @@ const convertCommanderIDToName = (commanderID: string): string => {
 
 const getCommanderData = (commanderID: string): CommanderData | null => {
   if (Object.prototype.hasOwnProperty.call(allCommanders, commanderID)) {
-    return allCommanders[commanderID];
+    let commander = allCommanders[commanderID] as CommanderData;
+    return decorateCommanderData(commander);
   } else {
     return null;
   }
 };
 
 const getCommanderByRaces = (raceName: RaceName): Array<CommanderData> => {
-  return Object.values(allCommanders).filter((commanderData) => {
-    return commanderData["races"][0] === raceName;
-  });
+  return Object.values(allCommanders)
+    .map((commander) => decorateCommanderData(commander))
+    .filter((commanderData) => {
+      return commanderData["races"][0] === raceName;
+    });
 };
 
 const getCommanderIconPath = (name: string): string => {
   return `/resources/exportedIcons/${name}.png`;
+};
+
+const decorateCommanderData = (commander: CommanderData): CommanderData => {
+  return {
+    ...commander,
+    abilities: commander.abilities.sort((a, b) => {
+      return +a.commandPoints < +b.commandPoints ? -1 : 1;
+    }),
+  };
 };
 
 export {

--- a/packages/web/src/coh/types.ts
+++ b/packages/web/src/coh/types.ts
@@ -5,8 +5,15 @@ interface CommanderData {
   commanderName: string;
   description: string;
   races: Array<string>;
-  abilities: Array<Record<string, any>>;
+  abilities: Array<CommanderAbility>;
 }
+
+type CommanderAbility = {
+  name: string;
+  description: string;
+  commandPoints: string;
+  icon: string;
+};
 
 interface IntelBulletinData {
   serverID: string;
@@ -61,6 +68,7 @@ interface PlayerCardDataArrayObject extends LaddersDataArrayObject {
 
 export type {
   CommanderData,
+  CommanderAbility,
   IntelBulletinData,
   RaceName,
   LaddersDataObject,

--- a/packages/web/src/pages/commanders/commanderDetails.tsx
+++ b/packages/web/src/pages/commanders/commanderDetails.tsx
@@ -6,6 +6,7 @@ import { ExportDate } from "../../components/export-date";
 import firebaseAnalytics from "../../analytics";
 import { getExportedIconPath, getGeneralIconPath } from "../../coh/helpers";
 import { commanderBase } from "../../titles";
+import { CommanderAbility } from "../../coh/types";
 
 export const CommanderDetails = () => {
   const { commanderID } = useParams<{
@@ -84,7 +85,7 @@ export const CommanderDetails = () => {
             <List
               itemLayout="horizontal"
               dataSource={commanderData.abilities}
-              renderItem={(item: Record<string, any>) => (
+              renderItem={(item: CommanderAbility) => (
                 <List.Item>
                   <List.Item.Meta
                     avatar={

--- a/packages/web/src/pages/commanders/commandersList.tsx
+++ b/packages/web/src/pages/commanders/commandersList.tsx
@@ -116,7 +116,7 @@ const CommanderAbilitiesComponent = (props: CommanderAbilityProps) => {
       <Row>
         {props.commanderAbilities.map((item: CommanderAbility) => {
           return (
-            <Col>
+            <Col key={item.name}>
               <Tooltip placement={"bottom"} title={item.description}>
                 <Avatar
                   alt={item.name}

--- a/packages/web/src/pages/commanders/commandersList.tsx
+++ b/packages/web/src/pages/commanders/commandersList.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect } from "react";
-import { Col, Row, List, Avatar } from "antd";
+import { Col, Row, List, Avatar, Badge, Tooltip } from "antd";
 import { getCommanderByRaces, getCommanderIconPath } from "../../coh/commanders";
 import { useParams } from "react-router";
-import { RaceName } from "../../coh/types";
+import { CommanderAbility, RaceName } from "../../coh/types";
 import routes from "../../routes";
 import { ExportDate } from "../../components/export-date";
 import { commanderBase } from "../../titles";
 import { capitalize } from "../../utils/helpers";
 import { Link } from "react-router-dom";
 import { Tip } from "../../components/tip";
+import { getExportedIconPath } from "../../coh/helpers";
+import Text from "antd/lib/typography/Text";
 
 export const CommandersList = () => {
   const { race } = useParams<{
@@ -69,9 +71,10 @@ export const CommandersList = () => {
                     avatar={
                       <Link to={routes.commanderByID(race, item.serverID)}>
                         <Avatar
-                          src={getCommanderIconPath(item.iconSmall)}
+                          src={getCommanderIconPath(item.iconlarge)}
                           shape="square"
-                          size={64}
+                          size={192}
+                          style={{ height: "192px", width: "144px" }}
                         />
                       </Link>
                     }
@@ -80,7 +83,12 @@ export const CommandersList = () => {
                         {item.commanderName}
                       </Link>
                     }
-                    description={item.description}
+                    description={
+                      <CommanderAbilitiesComponent
+                        commanderDescription={item.description}
+                        commanderAbilities={item.abilities}
+                      />
+                    }
                   />
                 </List.Item>
               </div>
@@ -90,5 +98,43 @@ export const CommandersList = () => {
         </Col>
       </Row>
     </div>
+  );
+};
+
+type CommanderAbilityProps = {
+  commanderAbilities: Array<CommanderAbility>;
+  commanderDescription: string;
+};
+
+const CommanderAbilitiesComponent = (props: CommanderAbilityProps) => {
+  return (
+    <>
+      <Row style={{ paddingBottom: 16, paddingTop: 16 }}>
+        <Text>{props.commanderDescription}</Text>
+      </Row>
+      <br />
+      <Row>
+        {props.commanderAbilities.map((item: CommanderAbility) => {
+          return (
+            <Col>
+              <Tooltip placement={"bottom"} title={item.description}>
+                <Avatar
+                  alt={item.name}
+                  src={getExportedIconPath(item.icon)}
+                  shape="square"
+                  size={64}
+                />
+                <Badge
+                  count={item.commandPoints}
+                  overflowCount={999}
+                  showZero
+                  offset={[0, -32]}
+                />
+              </Tooltip>
+            </Col>
+          );
+        })}
+      </Row>
+    </>
   );
 };


### PR DESCRIPTION
Hello, 

This PR addresses the requirements in issue #73, by displaying the abilities in the commanders list screen in a horizontal fashion. 

Also, I've managed to sort the abilities according to the command points, that sorting though will be applied to any screen that uses `getCommanderData` and `getCommanderByRaces` functions. 

I'm not really experienced with web development, since I come from a mobile development background (native Android), so there might be better ways to do things that I've specified, let me know please in case there were any.

Testing:

* I've added tests for `getCommanderData` and `getCommanderByRaces` functions.

Screenshot:
![image](https://user-images.githubusercontent.com/297007/142729422-60e98996-8ce8-42ab-8ac4-810aa4149bc4.png)
