### PR TITLE
Simplify IPC redux state syncing

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,7 +51,6 @@
     "compare-versions": "^4.1.3",
     "date-fns": "^2.28.0",
     "electron-is-packaged": "^1.0.2",
-    "electron-redux": "^1.5.4",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^8.0.1",
     "express": "^4.17.2",

--- a/packages/app/src/main/applicationStore.ts
+++ b/packages/app/src/main/applicationStore.ts
@@ -3,7 +3,7 @@ import { ApplicationSettings, ApplicationState, WindowStates } from "../redux/st
 import { actions, ReduxStore } from "../redux/slice";
 import { configureMainStore } from "../redux/configureStoreMain";
 import { AnyAction, Unsubscribe } from "@reduxjs/toolkit";
-import { app, ipcMain } from "electron";
+import { app } from "electron";
 import { defaultSettings, defaultWindowStates, startupGameData } from "../redux/defaultState";
 import axios from "axios";
 import config from "./config";
@@ -70,9 +70,6 @@ export class ApplicationStore {
       },
     );
     this.unsubscriber = this.runtimeStore.subscribe(this.runtimeStoreSubscriber);
-
-    // Used to sync redux stores on renderers with the main store when they get created
-    ipcMain.on("syncStores", this.storeSyncer);
   }
 
   getSavedSettings(): ApplicationSettings {
@@ -95,10 +92,6 @@ export class ApplicationStore {
     this.fileStore.set("windowStates", windowStates);
   }
 
-  protected storeSyncer = (event: Electron.IpcMainEvent): void => {
-    event.sender.send("updateStore", this.runtimeStore.getState());
-  };
-
   protected runtimeStoreSubscriber = (): void => {
     // update file store on changes
     this.setSavedSettings(this.runtimeStore.getState().settings);
@@ -106,7 +99,6 @@ export class ApplicationStore {
   };
 
   destroy(): void {
-    ipcMain.removeListener("syncStores", this.storeSyncer);
     this.unsubscriber();
   }
 }

--- a/packages/app/src/redux/configureStoreMain.ts
+++ b/packages/app/src/redux/configureStoreMain.ts
@@ -1,14 +1,30 @@
-import { configureStore, EnhancedStore } from "@reduxjs/toolkit";
-import { forwardToRenderer, triggerAlias, replayActionMain } from "electron-redux";
+import { configureStore, EnhancedStore, Middleware } from "@reduxjs/toolkit";
+import { BrowserWindow, ipcMain } from "electron";
 import applicationReducer from "./slice";
 import { ApplicationState } from "./state";
 
 export const configureMainStore = (initialState: ApplicationState): EnhancedStore => {
+  // middleware that sends updates to renderers
+  const forwardToRenderer: Middleware = (store) => (next) => (action) => {
+    const result = next(action);
+    const browserWindows = BrowserWindow.getAllWindows();
+    browserWindows.forEach((browserwindow) => {
+      browserwindow.webContents.send("ReduxUpdate", store.getState());
+    });
+    return result;
+  };
   const store = configureStore({
     reducer: applicationReducer,
     preloadedState: initialState,
-    middleware: [triggerAlias, forwardToRenderer],
+    middleware: [forwardToRenderer],
   });
-  replayActionMain(store);
+  // listen to init requests from renderer
+  ipcMain.on("ReduxInitialize", (event) => {
+    event.sender.send("ReduxUpdate", store.getState());
+  });
+  // listen to dispatch calls from renderer
+  ipcMain.on("ReduxDispatch", (event, args) => {
+    store.dispatch(args);
+  });
   return store;
 };

--- a/packages/app/src/redux/configureStoreRenderer.ts
+++ b/packages/app/src/redux/configureStoreRenderer.ts
@@ -1,15 +1,38 @@
-import { configureStore, EnhancedStore } from "@reduxjs/toolkit";
-import { forwardToMain, replayActionRenderer } from "electron-redux";
-import applicationReducer from "./slice";
+import { configureStore, EnhancedStore, Middleware, Reducer } from "@reduxjs/toolkit";
+import { ipcRenderer } from "electron";
+import applicationReducer, { initialState } from "./slice";
+import { ApplicationState } from "./state";
 
 export const configureRendererStore = (): EnhancedStore => {
+  // intercept dispatch from renderer and send to main
+  const forwardToMain: Middleware = (store) => (next) => (action) => {
+    if (action.type !== "ReduxUpdate") {
+      ipcRenderer.send("ReduxDispatch", action);
+    } else {
+      return next(action);
+    }
+  };
+  const updateableReducer: Reducer<ApplicationState> = (state, action) => {
+    if (action.type === "ReduxUpdate") {
+      return action.payload;
+    } else {
+      return applicationReducer(state, action);
+    }
+  };
   const store = configureStore({
-    reducer: applicationReducer,
-
+    reducer: updateableReducer,
+    preloadedState: initialState,
     middleware: [forwardToMain],
   });
-
-  replayActionRenderer(store);
+  // send request for initial state
+  ipcRenderer.send("ReduxInitialize");
+  // listen to updates from main
+  ipcRenderer.on("ReduxUpdate", (event, args: ApplicationState) => {
+    store.dispatch({
+      type: "ReduxUpdate",
+      payload: args,
+    });
+  });
 
   return store;
 };

--- a/packages/app/src/redux/slice.ts
+++ b/packages/app/src/redux/slice.ts
@@ -5,11 +5,8 @@ import {
   ApplicationState,
   GameData,
   GameState,
-  LadderStats,
-  SideData,
   StreamOverlayPositions,
   WindowState,
-  WindowStates,
 } from "./state";
 
 export const initialState: ApplicationState = {
@@ -17,22 +14,6 @@ export const initialState: ApplicationState = {
   windowStates: defaultWindowStates,
   game: startupGameData,
   updateCounter: 0,
-};
-
-const cloneLadderStatArray = (array: LadderStats[]) => {
-  return array.map((ladderStat) => {
-    const members = ladderStat.members.map((member) => Object.assign({}, member));
-    const newLadderStat = Object.assign({}, ladderStat);
-    newLadderStat.members = members;
-    return newLadderStat;
-  });
-};
-const cloneSideData = (sideData: SideData): SideData => {
-  return {
-    side: sideData.side,
-    solo: cloneLadderStatArray(sideData.solo),
-    teams: cloneLadderStatArray(sideData.teams),
-  };
 };
 
 export const slice = createSlice({
@@ -99,33 +80,6 @@ export const slice = createSlice({
     },
     setGameState: (state, { payload }: PayloadAction<GameState>) => {
       state.game.state = payload;
-    },
-    setStore: (state, { payload }: PayloadAction<ApplicationState>) => {
-      state.game = payload.game;
-      state.settings = payload.settings;
-      state.updateCounter = payload.updateCounter;
-    },
-    update: (state, { payload }: PayloadAction) => {
-      // make a deep copy of state
-      state.settings = Object.assign({}, state.settings);
-      const newWindowStates: WindowStates = {
-        main: Object.assign({}, state.windowStates.main),
-        settings: Object.assign({}, state.windowStates.settings),
-        about: Object.assign({}, state.windowStates.settings),
-        web: Object.assign({}, state.windowStates.settings),
-      };
-      state.windowStates = newWindowStates;
-      const newGameData: GameData = {
-        found: state.game.found,
-        state: state.game.state,
-        type: state.game.type,
-        map: state.game.map,
-        winCondition: state.game.winCondition,
-        left: cloneSideData(state.game.left),
-        right: cloneSideData(state.game.right),
-      };
-      state.game = newGameData;
-      state.updateCounter = state.updateCounter + 1;
     },
   },
 });

--- a/packages/app/src/renderer/windows/about/index.tsx
+++ b/packages/app/src/renderer/windows/about/index.tsx
@@ -39,8 +39,6 @@ declare global {
   }
 }
 
-window.electron.ipcRenderer.syncStores();
-
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={window.electron.store}>

--- a/packages/app/src/renderer/windows/main/index.tsx
+++ b/packages/app/src/renderer/windows/main/index.tsx
@@ -39,8 +39,6 @@ declare global {
   }
 }
 
-window.electron.ipcRenderer.syncStores();
-
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={window.electron.store}>

--- a/packages/app/src/renderer/windows/preload.tsx
+++ b/packages/app/src/renderer/windows/preload.tsx
@@ -1,19 +1,11 @@
 import { contextBridge, ipcRenderer, shell } from "electron";
-import { actions } from "../../redux/slice";
 import { configureRendererStore } from "../../redux/configureStoreRenderer";
 
 const store = configureRendererStore();
 
-ipcRenderer.on("updateStore", (event, args) => {
-  store.dispatch(actions.setStore(args));
-});
-
 contextBridge.exposeInMainWorld("electron", {
   store: store,
   ipcRenderer: {
-    syncStores() {
-      ipcRenderer.send("syncStores");
-    },
     showProfile(steamID: string) {
       ipcRenderer.send("showProfile", steamID);
     },

--- a/packages/app/src/renderer/windows/settings/index.tsx
+++ b/packages/app/src/renderer/windows/settings/index.tsx
@@ -39,8 +39,6 @@ declare global {
   }
 }
 
-window.electron.ipcRenderer.syncStores();
-
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={window.electron.store}>


### PR DESCRIPTION
Syncing the redux store from the main process with the renderer processes was rather complicated. And this additional complexity made extending the redux state more complicated. 