### PR TITLE
Fix exit run in tray mode

### DIFF
--- a/packages/app/src/main/applicationManager.ts
+++ b/packages/app/src/main/applicationManager.ts
@@ -152,9 +152,7 @@ export class ApplicationManager {
         this.createTray();
       } else {
         this.inTrayMode = false;
-        if (!this.mainWindow.isVisible()) {
-          this.mainWindow.show();
-        }
+        this.showMainWindow();
         this.tray.destroy();
       }
     }


### PR DESCRIPTION
When you disable run in tray and no main window is open it throws an error.